### PR TITLE
Add command to clear members from Inductees role

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "ts-node src/Bot.ts"
+    "start": "ts-node src/Bot.ts",
+    "deploy:global": "ts-node src/deploy-global.ts",
+    "deploy:testing": "ts-node src/deploy-testing.ts"
   },
   "repository": {
     "type": "git",

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -7,8 +7,8 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 import { eventPages } from "./event-pages";
-import type { IByte, IEvent } from "./schemas/byte";
 import { getEventPoints } from "./functions/get-points";
+import type { IByte, IEvent } from "./schemas/byte";
 const { Client, GatewayIntentBits } = require("discord.js");
 const { token, connectionString } = require("../config.json");
 const { connect, mongoose } = require("mongoose");
@@ -17,7 +17,11 @@ const Byte = require("./schemas/byte");
 console.log("Bot is starting...");
 
 export const client = new Client({
-  intents: [GatewayIntentBits.Guilds],
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMembers,
+    GatewayIntentBits.GuildPresences,
+  ],
 });
 
 client.commands = new Collection();
@@ -88,7 +92,7 @@ client.on(
           .addFields({
             name: "Points Earned",
             value: `${getEventPoints(entry, selected.total_mems)}`,
-          }, {name: "Date", value: entry.date.toLocaleDateString()});
+          }, { name: "Date", value: entry.date.toLocaleDateString() });
       });
 
       eventPages(interaction, pages);

--- a/src/commands/moderation/reset-inductees.ts
+++ b/src/commands/moderation/reset-inductees.ts
@@ -1,0 +1,80 @@
+import {
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+  Role,
+  SlashCommandBuilder,
+  bold,
+  inlineCode,
+  roleMention,
+} from "discord.js";
+
+import {
+  isMissingAccessError,
+  isMissingPermissionsError,
+} from "../../utils/errors.utils";
+import { clearRole } from "../../utils/moderation.utils";
+
+const INDUCTEES_ROLE_ID = "778438274695036957";
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("resetinductees")
+    .setDescription("Remove the Inductees role from every member.")
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  execute: clearInducteesRole,
+};
+
+async function clearInducteesRole(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const { guild } = interaction;
+  if (!guild) {
+    await interaction.reply(
+      "⚠️ This command can only be used within the UPE server.",
+    );
+    return;
+  }
+
+  const role = guild.roles.cache.get(INDUCTEES_ROLE_ID);
+  if (!role) {
+    await interaction.reply({
+      content:
+        "⚠️ Could not find the inductee role " +
+        `(expected role with ID ${inlineCode(INDUCTEES_ROLE_ID)}).`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await clearRoleAndReply(role, interaction);
+}
+
+async function clearRoleAndReply(
+  role: Role,
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const numInductees = role.members.size;
+
+  try {
+    await clearRole(role);
+  } catch (error) {
+    if (isMissingAccessError(error) || isMissingPermissionsError(error)) {
+      console.error("ERROR: bot is not allowed to remove roles.");
+      await interaction.reply({
+        content: "⚠️ I'm not allowed to perform this action!",
+        ephemeral: true,
+      });
+      return;
+    }
+    throw error; // Propagate to outer handler.
+  }
+
+  console.log(`Removed role "${role.name}" from ${numInductees} members.`);
+
+  await interaction.reply({
+    content:
+      `Removed ${roleMention(INDUCTEES_ROLE_ID)} ` +
+      `from all members (${bold(numInductees.toString())} affected).`,
+    allowedMentions: { parse: [] },
+  });
+}

--- a/src/utils/errors.utils.ts
+++ b/src/utils/errors.utils.ts
@@ -1,0 +1,29 @@
+import { DiscordAPIError } from "discord.js";
+
+/**
+ * See: https://discord.com/developers/docs/topics/opcodes-and-status-codes
+ */
+export type DiscordAPIErrorWithCode<Opcode extends number>
+  = DiscordAPIError & { code: Opcode };
+
+/**
+ * DiscordAPIError[50001]: `Missing access`. This can happen if the bot is
+ * missing the required role permissions. Confusingly, this is distinct from
+ * DiscordAPIError[50013]: `You lack permissions to perform that action`.
+ */
+export function isMissingAccessError(
+  error: unknown,
+): error is DiscordAPIErrorWithCode<50001> {
+  return error instanceof DiscordAPIError && error.code === 50001;
+}
+
+/**
+ * DiscordAPIError[50013]: `You lack permissions to perform that action`. This
+ * can happen if, for example, the bot tries to moderate a user whose highest
+ * role is higher than the bot's highest role.
+ */
+export function isMissingPermissionsError(
+  error: unknown,
+): error is DiscordAPIErrorWithCode<50013> {
+  return error instanceof DiscordAPIError && error.code === 50013;
+}

--- a/src/utils/moderation.utils.ts
+++ b/src/utils/moderation.utils.ts
@@ -1,0 +1,10 @@
+import { Role } from "discord.js";
+
+/**
+ * Remove the specified role from all of its members.
+ */
+export async function clearRole(role: Role): Promise<void> {
+  for (const member of role.members.values()) {
+    await member.roles.remove(role);
+  }
+}


### PR DESCRIPTION
## Motivation

At the moment, members are responsible for assigning themselves the `@Inductees` role to identify themselves as inductees. However, many of them forget or cannot be bothered to manually remove it after induction. At the time of writing this PR, there are **53 members** with the `@Inductees` role despite it not being induction season; some such members are even alumni already. While pretty trivial, this PR introduces a command as just a simple quality-of-life feature that helps reset the role (such as after every induction season).

## Changes

### Feature

Added the `/resetinductees` application command:

* Takes zero arguments.
* Requires by default the **Administrator** Discord permission.
* Removes the `@Inductees` role from every member with that role.

### Refactors

Auxiliary changes introduced in this PR:

* Added npm scripts to abstract entry to the `deploy-global.ts` and `deploy-testing.ts` scripts.
* Added the `GuildMembers` and `GuildPresences` gateway intents for the bot to be able to operate on server members, including offline ones.
* Added `errors.utils.ts` for type guards identifying specific [Discord API error opcodes](https://discord.com/developers/docs/topics/opcodes-and-status-codes) in a readable, TypeScript-friendly fashion.

No changes were made to `config.json` or the MongoDB/Mongoose setup.

## Action Required

If this feature is accepted, there is some required action on the Discord side. Because this feature operates on roles, it requires the following privileged configuration:

* [ ] The **Manage Roles** Discord permission must be enabled.
* [x] The *bot's* highest role must be higher than `@Inductees`. Last I checked, the `@bots` role is the literal highest role in the server, so this shouldn't be a problem.

> [!WARNING]
> I tested this feature on a private server, and it seems to work as expected. Depending on how much you trust me and/or your code review skills, it may be worthwhile to double check yourself that it works on some dummy role within the real UPE server first by substituting `INDUCTEES_ROLE_ID`, and then revert it to the real role ID.