### PR TITLE
Add command to assign inductees role based on CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ dist
 config.json
 
 event-pics/
+
+# Various data files
+inductees.csv

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@discordjs/rest": "^1.1.0",
+        "csv-string": "^4.1.1",
         "discord.js": "^14.8.0",
         "image-downloader": "^4.3.0",
         "mongoose": "^7.0.3"
@@ -257,6 +258,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/csv-string": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/csv-string/-/csv-string-4.1.1.tgz",
+      "integrity": "sha512-KGvaJEZEdh2O/EVvczwbPLqJZtSQaWQ4cEJbiOJEG4ALq+dBBqNmBkRXTF4NV79V25+XYtiqbco1IWrmHLm5FQ==",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/alexanderhwang02/upe-discord-bot#readme",
   "dependencies": {
     "@discordjs/rest": "^1.1.0",
+    "csv-string": "^4.1.1",
     "discord.js": "^14.8.0",
     "image-downloader": "^4.3.0",
     "mongoose": "^7.0.3"

--- a/src/commands/moderation/assign-inductees.ts
+++ b/src/commands/moderation/assign-inductees.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+
+import * as CSV from "csv-string";
+import {
+  ChatInputCommandInteraction,
+  DiscordAPIError,
+  EmbedBuilder,
+  Guild,
+  GuildMember,
+  PermissionFlagsBits,
+  Role,
+  SlashCommandBuilder,
+  inlineCode,
+} from "discord.js";
+
+import { makeErrorEmbed } from "../../utils/errors.utils";
+import { INDUCTEES_ROLE_ID } from "../../utils/snowflakes.utils";
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName("assigninductees")
+    .setDescription("Assign the Inductees role to all registered inductees.")
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  execute: assignInducteesRole,
+};
+
+const INDUCTEE_INFO_CSV_PATH = "inductees.csv"; // Placed at CWD for now.
+
+async function assignInducteesRole(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const { guild } = interaction;
+  if (!guild) {
+    await interaction.reply({
+      embeds: [makeErrorEmbed(
+        "This command can only be used within the UPE server.",
+      )],
+    });
+    return;
+  }
+
+  const role = guild.roles.cache.get(INDUCTEES_ROLE_ID);
+  if (!role) {
+    await interaction.reply({
+      embeds: [makeErrorEmbed(
+        "Could not find the inductee role " +
+        `(expected role with ID ${inlineCode(INDUCTEES_ROLE_ID)}).`,
+      )],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  // Not sure how long this takes with many inductees, so just in case.
+  await interaction.deferReply();
+
+  const usernames = parseInducteeUsernamesFromCSV();
+  const [members, notFound] = await getMembersFromUsernames(usernames, guild);
+  const [succeeded, failed] = await assignInducteesRoleToMembers(members);
+
+  const embed = prepareResponseEmbed(succeeded, notFound, failed, role);
+  await interaction.editReply({ embeds: [embed] });
+}
+
+function parseInducteeUsernamesFromCSV(): string[] {
+  const content = fs.readFileSync(INDUCTEE_INFO_CSV_PATH).toString();
+  const [header, ...rows] = CSV.parse(content);
+  if (header === undefined || rows.length === 0) {
+    console.error(`WARNING: ${INDUCTEE_INFO_CSV_PATH} is empty!`);
+    return [];
+  }
+  const usernameColumnIndex = header.indexOf("Discord Username");
+  const usernames = rows.map(row => row[usernameColumnIndex]);
+  return usernames;
+}
+
+async function getMembersFromUsernames(
+  usernames: string[],
+  guild: Guild,
+): Promise<[
+  foundMembers: GuildMember[],
+  notFoundUsernames: string[],
+]> {
+  const foundMembers: GuildMember[] = [];
+  const notFoundUsernames: string[] = [];
+
+  for (const username of usernames) {
+    const members = await guild.members.fetch({ query: username, limit: 1 });
+
+    // Unpack the singular member.
+    const [member] = members.values();
+
+    // Query returned no results or the username doesn't match for some reason.
+    if (!member || member.user.username !== username) {
+      notFoundUsernames.push(username);
+      continue;
+    }
+
+    foundMembers.push(member);
+  }
+
+  return [foundMembers, notFoundUsernames];
+}
+
+async function assignInducteesRoleToMembers(
+  members: GuildMember[],
+): Promise<[
+  succeededMembers: GuildMember[],
+  failedMembers: GuildMember[],
+]> {
+  const succeededMembers: GuildMember[] = [];
+  const failedMembers: GuildMember[] = [];
+
+  for (const member of members) {
+    try {
+      await member.roles.add(INDUCTEES_ROLE_ID);
+      succeededMembers.push(member);
+    } catch (error) {
+      const { code, message } = error as DiscordAPIError;
+      console.error(
+        `FAILED to assign Inductees role to @${member.user.username}: ` +
+        `DiscordAPIError[${code}] ${message}`,
+      );
+      failedMembers.push(member);
+    }
+  }
+
+  return [succeededMembers, failedMembers];
+}
+
+function prepareResponseEmbed(
+  succeeded: GuildMember[],
+  notFound: string[],
+  failed: GuildMember[],
+  role: Role,
+): EmbedBuilder {
+  const successString = succeeded.length > 0 ? (
+    `✅ Assigned ${role} to ${succeeded.length} member(s)!`
+  ) : "";
+
+  const notFoundString = notFound.length > 0 ? (
+    "⚠️ It doesn't seem like these users are in the server:\n" +
+    notFound.map(username => inlineCode(`@${username}`)).join(", ")
+  ) : "";
+
+  const failedString = failed.length > 0 ? (
+    "🚨 An error occurred when trying to give these members the role:\n" +
+    failed.join(", ")
+  ) : "";
+
+  const allGood = notFound.length === 0 && failed.length === 0;
+  if (allGood) {
+    const embed = new EmbedBuilder()
+      .setDescription(successString || "🤔 No inductees to assign!")
+      .setColor(role.color);
+    return embed;
+  }
+
+  const descriptionWithErrors = [
+    successString,
+    notFoundString,
+    failedString,
+  ].filter(Boolean).join("\n\n");
+
+  const embed = makeErrorEmbed(descriptionWithErrors);
+  return embed;
+}

--- a/src/commands/moderation/assign-inductees.ts
+++ b/src/commands/moderation/assign-inductees.ts
@@ -16,17 +16,22 @@ import {
 import { makeErrorEmbed } from "../../utils/errors.utils";
 import { INDUCTEES_ROLE_ID } from "../../utils/snowflakes.utils";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("assigninductees")
-    .setDescription("Assign the Inductees role to all registered inductees.")
-    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
-  execute: assignInducteesRole,
-};
+const COMMAND_NAME = "assigninductees";
 
 const INDUCTEE_INFO_CSV_PATH = "inductees.csv"; // Placed at CWD for now.
+const FIRST_NAME_COL_NAME = "Preferred First Name";
+const LAST_NAME_COL_NAME = "Preferred Last Name";
+const DISCORD_USERNAME_COL_NAME = "Discord Username";
 
-async function assignInducteesRole(
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName(COMMAND_NAME)
+    .setDescription("Update all server members that are registered inductees.")
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+  execute: updateInducteeMembers,
+};
+
+async function updateInducteeMembers(
   interaction: ChatInputCommandInteraction,
 ): Promise<void> {
   const { guild } = interaction;
@@ -42,37 +47,56 @@ async function assignInducteesRole(
   const role = guild.roles.cache.get(INDUCTEES_ROLE_ID);
   if (!role) {
     await interaction.reply({
+      ephemeral: true,
       embeds: [makeErrorEmbed(
         "Could not find the inductee role " +
         `(expected role with ID ${inlineCode(INDUCTEES_ROLE_ID)}).`,
       )],
-      ephemeral: true,
     });
     return;
   }
 
-  const usernames = parseInducteeUsernamesFromCSV();
-  if (usernames === "File Not Found") {
+  const inducteesInfo = parseInducteeInfoFromCSV();
+  if (inducteesInfo === "File Not Found") {
     await interaction.reply({
+      ephemeral: true,
       embeds: [makeErrorEmbed(
         "Could not find the file with inductee information!",
       )],
-      ephemeral: true,
     });
     return;
   }
+  if (inducteesInfo === "File Malformed") {
+    await interaction.reply({
+      ephemeral: true,
+      embeds: [makeErrorEmbed(
+        "Inductee info file has an unexpected format!",
+      )],
+    })
+    return;
+  }
 
-  // Not sure how long this takes with many inductees, so just in case.
+  // Not sure how long updating takes with many inductees, so just in case.
   await interaction.deferReply();
 
-  const [members, notFound] = await getMembersFromUsernames(usernames, guild);
-  const [succeeded, failed] = await assignInducteesRoleToMembers(members);
+  const [
+    succeeded,
+    notFound,
+    failed,
+  ] = await findAndUpdateMembersWithInfo(inducteesInfo, guild);
 
   const embed = prepareResponseEmbed(succeeded, notFound, failed, role);
   await interaction.editReply({ embeds: [embed] });
 }
 
-function parseInducteeUsernamesFromCSV(): string[] | "File Not Found" {
+type InducteeInfo = {
+  firstName: string;
+  lastName: string;
+  discordUsername: string;
+};
+
+function parseInducteeInfoFromCSV():
+  InducteeInfo[] | "File Not Found" | "File Malformed" {
   if (!fs.existsSync(INDUCTEE_INFO_CSV_PATH)) {
     console.error(`ERROR: file at path ${INDUCTEE_INFO_CSV_PATH} not found.`);
     return "File Not Found";
@@ -86,82 +110,137 @@ function parseInducteeUsernamesFromCSV(): string[] | "File Not Found" {
     return [];
   }
 
-  const usernameColumnIndex = header.indexOf("Discord Username");
-  const usernames = rows.map(row => row[usernameColumnIndex]);
-  return usernames;
+  const firstNameColumnIndex = header.indexOf(FIRST_NAME_COL_NAME);
+  if (firstNameColumnIndex === -1) {
+    console.error(`ERROR: no '${FIRST_NAME_COL_NAME}' column.`);
+    return "File Malformed";
+  }
+
+  const lastNameColumnIndex = header.indexOf(LAST_NAME_COL_NAME);
+  if (lastNameColumnIndex === -1) {
+    console.error(`ERROR: no '${LAST_NAME_COL_NAME}' column.`);
+    return "File Malformed";
+  }
+
+  const usernameColumnIndex = header.indexOf(DISCORD_USERNAME_COL_NAME);
+  if (usernameColumnIndex === -1) {
+    console.error(`ERROR: no '${DISCORD_USERNAME_COL_NAME}' column`);
+    return "File Malformed";
+  }
+
+  const inducteesInfo: InducteeInfo[] = rows.map(row => ({
+    firstName: row[firstNameColumnIndex],
+    lastName: row[lastNameColumnIndex],
+    discordUsername: row[usernameColumnIndex],
+  }));
+
+  return inducteesInfo;
 }
 
-async function getMembersFromUsernames(
-  usernames: string[],
+async function findAndUpdateMembersWithInfo(
+  inducteesInfo: InducteeInfo[],
   guild: Guild,
 ): Promise<[
-  foundMembers: GuildMember[],
-  notFoundUsernames: string[],
+  succeededMembers: GuildMember[],
+  notFoundUsers: InducteeInfo[],
+  failedMembers: GuildMember[]
 ]> {
-  const foundMembers: GuildMember[] = [];
-  const notFoundUsernames: string[] = [];
+  const succeededMembers: GuildMember[] = [];
+  const notFoundUsers: InducteeInfo[] = [];
+  const failedMembers: GuildMember[] = [];
 
-  for (const username of usernames) {
-    const members = await guild.members.fetch({ query: username, limit: 1 });
+  for (const inducteeInfo of inducteesInfo) {
+    const {
+      firstName,
+      lastName,
+      discordUsername: providedUsername,
+    } = inducteeInfo;
+
+    // Make the API call.
+    const members = await guild.members.fetch({
+      query: providedUsername,
+      limit: 1,
+    });
 
     // Unpack the singular member.
     const [member] = members.values();
 
     // Query returned no results or the username doesn't match for some reason.
-    if (!member || member.user.username !== username) {
-      notFoundUsernames.push(username);
+    if (!member || member.user.username !== providedUsername) {
+      notFoundUsers.push(inducteeInfo);
       continue;
     }
 
-    foundMembers.push(member);
-  }
+    // Do the actual updating.
+    const nickname = `${firstName} ${lastName}`;
+    const success =
+      await assignInducteeRole(member) &&
+      await updateMemberNickname(member, nickname);
 
-  return [foundMembers, notFoundUsernames];
-}
-
-async function assignInducteesRoleToMembers(
-  members: GuildMember[],
-): Promise<[
-  succeededMembers: GuildMember[],
-  failedMembers: GuildMember[],
-]> {
-  const succeededMembers: GuildMember[] = [];
-  const failedMembers: GuildMember[] = [];
-
-  for (const member of members) {
-    try {
-      await member.roles.add(INDUCTEES_ROLE_ID);
+    if (success) {
       succeededMembers.push(member);
-    } catch (error) {
-      const { code, message } = error as DiscordAPIError;
-      console.error(
-        `FAILED to assign Inductees role to @${member.user.username}: ` +
-        `DiscordAPIError[${code}] ${message}`,
-      );
+    } else {
       failedMembers.push(member);
     }
   }
 
-  return [succeededMembers, failedMembers];
+  return [succeededMembers, notFoundUsers, failedMembers];
+}
+
+async function assignInducteeRole(member: GuildMember): Promise<boolean> {
+  try {
+    await member.roles.add(INDUCTEES_ROLE_ID);
+    return true;
+  } catch (error) {
+    const { code, message } = error as DiscordAPIError;
+    console.error(
+      `FAILED to assign Inductees role to @${member.user.username}: ` +
+      `DiscordAPIError[${code}] ${message}`,
+    );
+    return false;
+  }
+}
+
+async function updateMemberNickname(
+  member: GuildMember,
+  nickname: string,
+): Promise<boolean> {
+  try {
+    await member.setNickname(
+      nickname,
+      `/${COMMAND_NAME}: used inductee's provided preferred name`,
+    );
+    return true;
+  } catch (error) {
+    const { code, message } = error as DiscordAPIError;
+    console.error(
+      `FAILED to update @${member.user.username} nickname to '${nickname}': ` +
+      `DiscordAPIError[${code}] ${message}`,
+    );
+    return false;
+  }
 }
 
 function prepareResponseEmbed(
   succeeded: GuildMember[],
-  notFound: string[],
+  notFound: InducteeInfo[],
   failed: GuildMember[],
   role: Role,
 ): EmbedBuilder {
   const successString = succeeded.length > 0 ? (
-    `✅ Assigned ${role} to ${succeeded.length} member(s)!`
+    `✅ Assigned ${role} and updated nickname for ${succeeded.length} members!`
   ) : "";
 
   const notFoundString = notFound.length > 0 ? (
     "⚠️ It doesn't seem like these users are in the server:\n" +
-    notFound.map(username => inlineCode(`@${username}`)).join(", ")
+    notFound.map(info => {
+      const { firstName, lastName, discordUsername: username } = info;
+      return inlineCode(`@${username}`) + " " + `(${firstName} ${lastName})`;
+    }).join(", ")
   ) : "";
 
   const failedString = failed.length > 0 ? (
-    "🚨 An error occurred when trying to give these members the role:\n" +
+    "🚨 I wasn't allowed to update these members:\n" +
     failed.join(", ")
   ) : "";
 

--- a/src/utils/errors.utils.ts
+++ b/src/utils/errors.utils.ts
@@ -1,4 +1,4 @@
-import { DiscordAPIError } from "discord.js";
+import { Colors, DiscordAPIError, EmbedBuilder } from "discord.js";
 
 /**
  * See: https://discord.com/developers/docs/topics/opcodes-and-status-codes
@@ -26,4 +26,32 @@ export function isMissingPermissionsError(
   error: unknown,
 ): error is DiscordAPIErrorWithCode<50013> {
   return error instanceof DiscordAPIError && error.code === 50013;
+}
+
+export function makeErrorEmbed(message: string): EmbedBuilder;
+export function makeErrorEmbed(title: string, message: string): EmbedBuilder;
+export function makeErrorEmbed(
+  arg1: string,
+  arg2?: string,
+): EmbedBuilder {
+  let message: string;
+  let title: string | undefined;
+
+  if (arg2 === undefined) {
+    message = arg1;
+    title = undefined;
+  } else {
+    message = arg2;
+    title = arg1;
+  }
+
+  const embed = new EmbedBuilder()
+    .setDescription(message)
+    .setColor(Colors.Red);
+
+  if (title) {
+    embed.setTitle(title);
+  }
+
+  return embed;
 }


### PR DESCRIPTION
## Motivation

Feature requested by `@seraph02` (Alexander Hwang):

![image](https://github.com/alexanderhwang02/upe-discord-bot/assets/67369899/312f8dfa-8c37-4aec-b9d6-02fb5e6facd1)

## Overview

The new `/assigninductees` application command reads from a local CSV file, extracts the Discord usernames, and gives those members the `@Inductees` roles.

* Signature: `/assigninductees` (no options)
* Requires the **Administrator** Discord permission to be able to view and use the command.
 
The implementation tries its best in error handling. It tries to assign the role to as many members as possible (instead of short-circuiting on the first error). Members that aren't found or those for which a Discord API error occurred are collected and outputted as part of the response. Example response (using myself and Alex as guinea pigs, along with 2 intentionally non-existent usernames):

![image](https://github.com/alexanderhwang02/upe-discord-bot/assets/67369899/87248176-33f6-4f06-8a5f-01e47505a0cf)

## Action Needed

This implementation assumes that the inductee CSV file is placed at the current working directory of the bot's runtime (i.e. the **project root**). The file should be named **inductees.csv**, but it and its corresponding path name constant can be edited if needed. The file contains PII, so it is `.gitignore`d.

Furthermore, the format of the CSV file should be the same as what was shared in [the Discord thread for this feature](https://discord.com/channels/778420751995895819/1227114300858961953/1227128886840528958). Technically, as long as the column with Discord usernames is preserved and named exactly `Discord Username`, it should be fine, as the implementation searches for the column index whose header is titled that string instead of using a hard-coded column number.
