### PR TITLE
Add some safeties to command responses

### DIFF
--- a/src/utils/moderation.utils.ts
+++ b/src/utils/moderation.utils.ts
@@ -3,8 +3,8 @@ import { Role } from "discord.js";
 /**
  * Remove the specified role from all of its members.
  */
-export async function clearRole(role: Role): Promise<void> {
+export async function clearRole(role: Role, reason?: string): Promise<void> {
   for (const member of role.members.values()) {
-    await member.roles.remove(role);
+    await member.roles.remove(role, reason);
   }
 }


### PR DESCRIPTION
Minor upgrades to `/resetinductees` (#1) and `/assigninductees` (#3).

`/resetinductees`:

* Mainly, the callback now defers the reply as clearing roles from many
  inductees is likely to time out (I suspect this already happened
  once).
* Includes a reason for the audit log when clearing the role.
* Slight improvement to presentation: reply with embed and tweak log
  statement.

`/assigninductees`:

These changes help prevent the description in the response embed from
exceeding the character limit.

* Removed mentions from the "\<num\> affected" section. In practice,
  admins will likely run this only once instead of incrementally as
  responses roll in, so there will be a LOT of inductees newly affected.
* Truncated the mentions for the "missing" section to only list the
  first 50 usernames. I anticipate that many people do not properly
  write their Discord username in the Google form and/or forget to
  actually join the server, so it is useful to know exactly who the bot
  couldn't find. In case the full list doesn't fit in the truncation,
  the callback also logs all the names and usernames to stderr as a list
  so admins know whom to reach out to.
* Truncated the mentions for the "error" section to only list the first
  5 mentions. In practice, this should not show up because the most
  likely reasons an API error would occur are permission-related errors,
  which we have already fixed on the Discord side. Furthermore, if they
  did show up, it is likely that many if not all inductees will cause
  the same error, and we do not need a dump of literally every mention.