### PR TITLE
Loosen inductee user search requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,4 @@ config.json
 event-pics/
 
 # Various data files
-inductees.csv
+*.csv


### PR DESCRIPTION
Thought I'd merge this anyway, as it improved the inductee discovery process by a bit. It still misses many members, but I think most of them are just not in the server yet.

* Instead of rejecting users returned by `fetch()` that aren't exact
  matches, the loop still makes the update on them and just logs a
  warning to stderr.
* Log a statement for each inductee being processed to the console to
  give a better sense of progress.
* Improve post-processing/cleaning of usernames from CSV file.

Other approaches I've tried are documented in the [#bot-testing channel, starting from around this message](https://discord.com/channels/778420751995895819/1090790068974796940/1228209118230085742).

