### PR TITLE
Add /linktree as shortcut for induction Linktree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@discordjs/rest": "^1.1.0",
+        "cheerio": "^1.0.0-rc.12",
         "csv-string": "^4.1.1",
         "discord.js": "^14.8.0",
         "image-downloader": "^4.3.0",
         "mongoose": "^7.0.3"
       },
       "devDependencies": {
+        "@types/cheerio": "^0.22.35",
         "@types/node": "^18.15.10",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.2"
@@ -180,6 +182,15 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "node_modules/@types/cheerio": {
+      "version": "0.22.35",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
+      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
@@ -234,6 +245,11 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/bson": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
@@ -253,11 +269,73 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
     },
     "node_modules/csv-string": {
       "version": "4.1.1",
@@ -325,6 +403,68 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -363,6 +503,24 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/ieee754": {
@@ -520,6 +678,40 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+      "integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+      "dependencies": {
+        "domhandler": "^5.0.2",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/peek-readable": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
   "homepage": "https://github.com/alexanderhwang02/upe-discord-bot#readme",
   "dependencies": {
     "@discordjs/rest": "^1.1.0",
+    "cheerio": "^1.0.0-rc.12",
     "csv-string": "^4.1.1",
     "discord.js": "^14.8.0",
     "image-downloader": "^4.3.0",
     "mongoose": "^7.0.3"
   },
   "devDependencies": {
+    "@types/cheerio": "^0.22.35",
     "@types/node": "^18.15.10",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2"

--- a/src/commands/committee/committee.ts
+++ b/src/commands/committee/committee.ts
@@ -8,6 +8,7 @@ import {
   bold,
 } from "discord.js";
 
+import { addBroadcastOption } from "../../utils/options.utils";
 import {
   ADVOCACY_ROLE_ID,
   ALUMNI_ROLE_ID,
@@ -26,22 +27,18 @@ import {
   WEB_ROLE_ID,
 } from "../../utils/snowflakes.utils";
 
+const commandDefinition = new SlashCommandBuilder()
+  .setName("committee")
+  .setDescription("List details about a committee within UPE!")
+  .addRoleOption(input => input
+    .setName("committee_mention")
+    .setDescription("Role of the committee to view.")
+    .setRequired(true)
+  );
+addBroadcastOption(commandDefinition);
+
 module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("committee")
-    .setDescription("List details about a committee within UPE!")
-    .addRoleOption(input => input
-      .setName("committee_mention")
-      .setDescription("Role of the committee to view.")
-      .setRequired(true)
-    )
-    // TODO: Adding a flag for "broadcast"/"hidden" seems like it can be common
-    // across different commands, so this addition can be refactored into a
-    // helper function if need be.
-    .addBooleanOption(input => input
-      .setName("broadcast")
-      .setDescription("Whether to respond publicly instead of ephemerally.")
-    ),
+  data: commandDefinition,
   execute: listCommitteeDetails,
 };
 

--- a/src/commands/convenience/linktree.ts
+++ b/src/commands/convenience/linktree.ts
@@ -1,0 +1,154 @@
+import cheerio from "cheerio";
+import {
+  ChatInputCommandInteraction,
+  ColorResolvable,
+  EmbedBuilder,
+  SlashCommandBuilder,
+  bold,
+  hyperlink,
+} from "discord.js";
+
+import { addBroadcastOption } from "../../utils/options.utils";
+
+const COMMAND_NAME = "linktree";
+
+const INDUCTION_LINKTREE_URL = "https://linktr.ee/upe_induction";
+const UPE_BLUE: ColorResolvable = "#3067d3";
+
+const commandDefinition = new SlashCommandBuilder()
+  .setName(COMMAND_NAME)
+  .setDescription("Get the UPE Linktree links.")
+  .addBooleanOption(input => input
+    .setName("simple")
+    .setDescription("Just output the Linktree URL itself and nothing else.")
+  );
+addBroadcastOption(commandDefinition);
+
+module.exports = {
+  data: commandDefinition,
+  execute: displayUPELinktree,
+};
+
+async function displayUPELinktree(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const simple = interaction.options.getBoolean("simple");
+  const broadcast = interaction.options.getBoolean("broadcast");
+
+  let responseEmbed: EmbedBuilder;
+  if (simple) {
+    responseEmbed = prepareSimpleResponse();
+  }
+  else {
+    const linktreeHtml = await fetchHTMLOfWebPage(INDUCTION_LINKTREE_URL);
+    // Fetching failed, just display the Linktree link.
+    if (linktreeHtml === null) {
+      responseEmbed = prepareSimpleResponse();
+    }
+    else {
+      const linktreeEntries = extractLinktreeEntries(linktreeHtml);
+      responseEmbed = prepareExpandedResponse(linktreeEntries);
+    }
+  }
+
+  await interaction.reply({
+    embeds: [responseEmbed],
+    ephemeral: !broadcast,
+  });
+}
+
+type LinkEntry = {
+  redirectLink: string;
+  displayedText: string;
+};
+
+type CategoryLinks = {
+  name: string;
+  entries: LinkEntry[];
+}
+
+function prepareSimpleResponse(): EmbedBuilder {
+  return new EmbedBuilder()
+    .setDescription(INDUCTION_LINKTREE_URL)
+    .setColor(UPE_BLUE);
+}
+
+function prepareExpandedResponse(categories: CategoryLinks[]): EmbedBuilder {
+  function entryToHyperlink(entry: LinkEntry): string {
+    const { redirectLink, displayedText } = entry;
+    return hyperlink(displayedText, redirectLink);
+  }
+
+  function categoryToBulletedList(category: CategoryLinks): string {
+    const { name, entries } = category;
+    const bulletedList = entries
+      .map(entryToHyperlink)
+      .map(text => `* ${text}`)
+      .join("\n");
+    return `${bold(name)}\n${bulletedList}`;
+  }
+
+  const sections = categories.map(categoryToBulletedList);
+
+  const addendum = `Visit the Linktree here: ${INDUCTION_LINKTREE_URL}`;
+  sections.push(bold(addendum));
+
+  const description = sections.join("\n\n");
+
+  return new EmbedBuilder()
+    .setTitle("UPE Induction Linktree")
+    .setDescription(description)
+    .setColor(UPE_BLUE)
+    .setFooter({
+      text: "TIP: the Linktree is in the inductee channel topic too.",
+    });
+}
+
+async function fetchHTMLOfWebPage(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+    const html = await response.text();
+    return html;
+  } catch (error) {
+    const { name, message } = error as Error;
+    console.error(`ERROR: ${name} when fetching ${url}: ${message}`);
+    return null;
+  }
+}
+
+function extractLinktreeEntries(html: string): CategoryLinks[] {
+  /** Selector of the actual link buttons in the Linktree. */
+  const LINK_BUTTON_SELECTOR = 'a[data-testid="LinkButton"]';
+
+  const $ = cheerio.load(html);
+  const categories: CategoryLinks[] = [];
+
+  // The category titles are found as <h3>'s in the HTML. Traverse each <h3> and
+  // subsequent links to build each category.
+  $("h3").each((_, element) => {
+    const categoryName = $(element).text().trim();
+    const entries: LinkEntry[] = [];
+
+    // Traverse from the <h3>'s parent div to the next <div>'s containing the
+    // <a> elements.
+    let nextDiv = $(element).parent().next("div");
+
+    // Continue to traverse & extract links while <div>'s contain link buttons.
+    while (nextDiv.length && nextDiv.find(LINK_BUTTON_SELECTOR).length) {
+      const linkButtonElement = nextDiv.find(LINK_BUTTON_SELECTOR);
+
+      const redirectLink = $(linkButtonElement).attr("href") || "";
+      const displayedText = $(linkButtonElement).find("p").text().trim();
+      entries.push({ redirectLink, displayedText });
+
+      nextDiv = nextDiv.next("div");
+    }
+
+    categories.push({ name: categoryName, entries });
+  });
+
+  return categories;
+}

--- a/src/utils/options.utils.ts
+++ b/src/utils/options.utils.ts
@@ -1,0 +1,20 @@
+import { SlashCommandBuilder } from "discord.js";
+
+/**
+ * For some reason, some of the methods on a `SlashCommandBuilder` cause it to
+ * become the `Omit<...>` type, so this union accounts for that.
+ */
+type AnySlashCommandBuilder =
+  | SlashCommandBuilder
+  | Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">;
+
+export function addBroadcastOption(
+  commandDefinition: AnySlashCommandBuilder,
+  required: boolean = false,
+): void {
+  commandDefinition.addBooleanOption(input => input
+    .setName("broadcast")
+    .setDescription("Whether to respond publicly instead of ephemerally.")
+    .setRequired(required)
+  );
+}


### PR DESCRIPTION
## Motivation

I remember from when I was inducting that people often forget where the [induction Linktree](https://linktr.ee/upe_induction) is (or they didn't notice that it was literally in the inductee channel topic). Adding a command to bring up the Linktree from within Discord would be a nice quality-of-life feature. I don't know whom it may end up helping, but I thought it was cool.

It was originally going to be a stupid-simple "just respond with the URL lol" command, but in my continued habit of procrastinating homework, I took it a step further.

## Overview

The new application command `/linktree` brings up the induction Linktree from within Discord. Its signature:

```
/linktree Boolean(simple)? Boolean(broadcast)?
```

* The command responds **ephemerally** by default as to not clutter the channel it is invoked in. This can be overridden with the `broadcast` option, similar to the one introduced for `/committee` (#2).
* If fetching the Linktree webpage fails for some reason, the command defaults to just simply displaying the Linktree URL. This can also be forced with the `simple` option.

> [!NOTE]
>
> This does NOT hard-code the Linktree button texts and hyperlinks! This dynamically fetches the HTML of the actual UPE induction Linktree and parses out the categories and link buttons. They are then formatted into hyperlinks within an embed and displayed to the caller. This makes the command automatically adapt to changes to the Linktree, and as long as the URL doesn't change, this command can remain indefinitely useful for future induction seasons.

Example response:

![image](https://github.com/alexanderhwang02/upe-discord-bot/assets/67369899/4be0e621-5d1a-4b76-a079-77d126929c2e)

## Other Changes

An `addBroadcastOption` helper was added to deduplicate the pattern of adding a `broadcast` Boolean option to commands (specifying a public response instead of a default ephemeral response). This was left as a `// TODO` in #2 and has now been refactored into its own module, resolving the TODO as well.
